### PR TITLE
General Maintenance

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "laminas/laminas-component-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "require": {
@@ -33,10 +32,9 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^10.0",
-        "laminas/laminas-component-installer": "^2.8.0",
         "laminas/laminas-servicemanager": "^3.16.0",
         "lctrs/psalm-psr-container-plugin": "^1.6",
-        "phpunit/phpunit": "^9.5.23",
+        "phpunit/phpunit": "^9.5.24",
         "psalm/plugin-phpunit": "^0.17.0",
         "roave/security-advisories": "dev-latest",
         "vimeo/psalm": "^4.26.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89fe24ce0051c487ba57882372a5e234",
+    "content-hash": "63d81dd75ec80341371671fc0ff8533d",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -1490,73 +1490,6 @@
                 "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
             },
             "time": "2022-03-02T22:36:06+00:00"
-        },
-        {
-            "name": "laminas/laminas-component-installer",
-            "version": "2.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-component-installer.git",
-                "reference": "3c998d2b2755985c71cd4d5d9b294228f63d3a65"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-component-installer/zipball/3c998d2b2755985c71cd4d5d9b294228f63d3a65",
-                "reference": "3c998d2b2755985c71cd4d5d9b294228f63d3a65",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0"
-            },
-            "conflict": {
-                "zendframework/zend-component-installer": "*"
-            },
-            "require-dev": {
-                "composer/composer": "^2.1.9@RC",
-                "laminas/laminas-coding-standard": "~2.3.0",
-                "mikey179/vfsstream": "^1.6.10",
-                "phpunit/phpunit": "^9.5.19",
-                "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.22.0",
-                "webmozart/assert": "^1.10.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Laminas\\ComponentInstaller\\ComponentInstaller"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\ComponentInstaller\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Composer plugin for injecting modules and configuration providers into application configuration",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "component installer",
-                "composer",
-                "laminas",
-                "plugin"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-component-installer/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-component-installer/issues",
-                "rss": "https://github.com/laminas/laminas-component-installer/releases.atom",
-                "source": "https://github.com/laminas/laminas-component-installer"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2022-07-03T21:27:51+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,18 +6,15 @@
     <arg name="cache" value=".php_cs.cache"/>
     <arg name="colors"/>
 
-    <!-- Ignore warnings, show progress of the run and show sniff names -->
-    <arg value="nps"/>
+    <!-- show progress of the run and show sniff names -->
+    <arg value="ps"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>tests</file>
 
     <!-- Inherit rules from Doctrine Coding Standard -->
-    <rule ref="Doctrine">
-        <!-- Whilst this lib is compatible with 7.3, exclude this sniff -->
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
-    </rule>
+    <rule ref="Doctrine" />
 
     <rule ref="Generic.Formatting.MultipleStatementAlignment.NotSame">
         <severity>0</severity>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -7,6 +7,7 @@ namespace Netglue\PsrContainer\Postmark;
 use Postmark\PostmarkAdminClient;
 use Postmark\PostmarkClient;
 
+/** @final */
 class ConfigProvider
 {
     /** @return array{dependencies: array{factories: array<class-string, class-string>}} */

--- a/src/Exception/BadMethodCall.php
+++ b/src/Exception/BadMethodCall.php
@@ -6,6 +6,7 @@ namespace Netglue\PsrContainer\Postmark\Exception;
 
 use BadMethodCallException;
 
+/** @final */
 class BadMethodCall extends BadMethodCallException
 {
 }

--- a/src/Exception/MissingAccountKey.php
+++ b/src/Exception/MissingAccountKey.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 use function sprintf;
 
+/** @final */
 class MissingAccountKey extends RuntimeException
 {
     public static function withConfigPath(string $path): self

--- a/src/Exception/MissingServerKey.php
+++ b/src/Exception/MissingServerKey.php
@@ -8,6 +8,7 @@ use RuntimeException;
 
 use function sprintf;
 
+/** @final */
 class MissingServerKey extends RuntimeException
 {
     public static function withConfigPath(string $path): self

--- a/tests/AdminClientFactoryTest.php
+++ b/tests/AdminClientFactoryTest.php
@@ -14,7 +14,7 @@ use Psr\Container\ContainerInterface;
 class AdminClientFactoryTest extends TestCase
 {
     /** @var MockObject&ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     protected function setUp(): void
     {
@@ -57,7 +57,9 @@ class AdminClientFactoryTest extends TestCase
 
         $factory = new AdminClientFactory();
         $this->expectException(MissingAccountKey::class);
-        $this->expectExceptionMessage('Expected a non-empty string to use as the account api key at [postmark][account_token]');
+        $this->expectExceptionMessage(
+            'Expected a non-empty string to use as the account api key at [postmark][account_token]',
+        );
 
         $factory->__invoke($this->container);
     }

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -15,7 +15,7 @@ use Psr\Container\ContainerInterface;
 class ClientFactoryTest extends TestCase
 {
     /** @var MockObject&ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     protected function setUp(): void
     {
@@ -57,7 +57,9 @@ class ClientFactoryTest extends TestCase
         $this->containerWillReturnConfig($config);
         $factory = new ClientFactory();
         $this->expectException(MissingServerKey::class);
-        $this->expectExceptionMessage('Expected a non-empty string to use as the server api key at [postmark][server_token]');
+        $this->expectExceptionMessage(
+            'Expected a non-empty string to use as the server api key at [postmark][server_token]',
+        );
 
         $factory->__invoke($this->container);
     }

--- a/tests/LaminasServiceManagerIntegrationTest.php
+++ b/tests/LaminasServiceManagerIntegrationTest.php
@@ -16,8 +16,7 @@ use function array_merge;
 
 class LaminasServiceManagerIntegrationTest extends TestCase
 {
-    /** @var ServiceManager */
-    private $container;
+    private ServiceManager $container;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
- Update `phpcs` config to stop ignoring warnings and native property type hints
- Fixes CS violations
- "soft" marks all relevant classes as final
- drops laminas-component-installer dev dependency as it is unused
- bump patch versions of dev deps